### PR TITLE
Added backward compatibility with old git versions (vis-a-vis -C)

### DIFF
--- a/agouti.py
+++ b/agouti.py
@@ -9,8 +9,8 @@ import resource
 agoutiBase = os.path.dirname(os.path.realpath(sys.argv[0]))
 sys.path.insert(1, agoutiBase)
 
-__version__ = sp.check_output(shlex.split("git -C %s describe --tag --always --dirty"
-										  %(os.path.dirname(os.path.realpath(__file__)))))
+__version__ = sp.check_output(shlex.split("git describe --tag --always --dirty"),
+										  cwd=os.path.dirname(os.path.realpath(__file__)))
 
 from lib import agouti_log as agLOG
 from lib import agouti_sam as agBAM
@@ -242,11 +242,11 @@ def update_local(args):
 		sys.exit(1)
 	# Then compare local with remote
 	version.logger.info("Checking available updates of AGOUTI")
-	checkLocal = "git -C %s log -n 1 --pretty=\"%%H\"" %(repoDir)
-	localVersion = sp.check_output(shlex.split(checkLocal)).strip()
+	checkLocal = "git log -n 1 --pretty=\"%%H\""
+	localVersion = sp.check_output(shlex.split(checkLocal), cwd=repoDir).strip()
 #	if remoteVersion != localVersion:
-	gitCmd = "git -C %s ls-remote origin" %(repoDir)
-	heads = sp.check_output(shlex.split(gitCmd)).split("\n")
+	gitCmd = "git ls-remote origin"
+	heads = sp.check_output(shlex.split(gitCmd), cwd=repoDir).split("\n")
 	tags = []
 	dVersions = {}
 	for line in heads:
@@ -262,14 +262,14 @@ def update_local(args):
 	latesTag = sorted(tags)[-1]
 	latestHash = dVersions[latesTag]
 	if latestHash != localVersion:
-		gitCmd = "git -C %s fetch --all" %(repoDir)
-		p = sp.Popen(shlex.split(gitCmd), stdout=sp.PIPE, stderr=sp.PIPE)
+		gitCmd = "git fetch --all"
+		p = sp.Popen(shlex.split(gitCmd), stdout=sp.PIPE, stderr=sp.PIPE, cwd=repoDir)
 		pout, perr = p.communicate()
 		if p.returncode:
 			version.logger.error("git fetch error: %s" %(perr))
 			sys.exit(1)
-		gitCmd = "git -C %s checkout -q %s -b %s" %(repoDir, latesTag, latesTag.split("/")[-1])
-		p = sp.Popen(shlex.split(gitCmd), stdout=sp.PIPE, stderr=sp.PIPE)
+		gitCmd = "git checkout -q %s -b %s" %(latesTag, latesTag.split("/")[-1])
+		p = sp.Popen(shlex.split(gitCmd), stdout=sp.PIPE, stderr=sp.PIPE, cwd=repoDir)
 		pout, perr = p.communicate()
 		if p.returncode:
 			version.logger.error("git checkout error: %s" %(perr))


### PR DESCRIPTION
Without these changes, anyone with a pre-2.0 (or so) version of git will lack the `-C` flag, and AGOUTI will fail in every possible use-case due to the setting of `__version__` (line 12).  I don't know how common having old versions of git is, but the fix is simple enough that it should work for everyone:
Most if not all methods in the subprocess module have an argument `cwd` that performs the same function as the -C flag.  This includes `check_output()` and `Popen()`, which are the two used in AGOUTI.
